### PR TITLE
Reword description to make it clearer that memestra is not deprecated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Memestra!
 =========
 
-Memestra is a deprecated function usage checker.
+Memestra checks code for places where deprecated functions are called.
 
 Judging by the code layout, you'd guess it's in early alpha :-)
 


### PR DESCRIPTION
I read this originally as "Memestra is a deprecated (function usage checker)", but I should have read it as "Memestra is a (deprecated function) usage checker". I think this rewording makes it clearer?