### PR TITLE
Add full paths to sys.path

### DIFF
--- a/memestra/nbmemestra.py
+++ b/memestra/nbmemestra.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 import nbformat
 
 
-def nbmemestra_from_nbnode(nb, decorator):
+def nbmemestra_from_nbnode(nb, decorator, filepath):
     # Get code cells
     cells = nb.cells
     code_cells = [c for c in cells if c['cell_type'] == 'code']
@@ -22,7 +22,7 @@ def nbmemestra_from_nbnode(nb, decorator):
     code = '\n'.join(code_list)
 
     # Collect calls to deprecated functions
-    deprecated_list = memestra(StringIO(code), decorator)
+    deprecated_list = memestra(StringIO(code), decorator, filepath)
 
     # Map them to cells
     result = []
@@ -35,9 +35,9 @@ def nbmemestra_from_nbnode(nb, decorator):
     return result
 
 
-def nbmemestra(nbfile, decorator):
+def nbmemestra(nbfile, decorator, filepath):
     nb = nbformat.read(nbfile, 4)
-    return nbmemestra_from_nbnode(nb, decorator)
+    return nbmemestra_from_nbnode(nb, decorator, filepath)
 
 
 def register(dispatcher):

--- a/memestra/preprocessor.py
+++ b/memestra/preprocessor.py
@@ -12,7 +12,7 @@ class MemestraDeprecationChecker(Preprocessor):
     def preprocess(self, nb, resources):
         self.log.info("Using decorator '%s.%s' to check deprecated functions", self.decorator[0], self.decorator[1])
         deprecations = {}
-        for d in nbmemestra.nbmemestra_from_nbnode(nb, self.decorator):
+        for d in nbmemestra.nbmemestra_from_nbnode(nb, self.decorator, ""):
             code_cell_i = int(re.search(r"\[(\d+)\]", d[1]).group(1))
             deprecation = deprecations.get(code_cell_i, [])
             deprecation.append(d)

--- a/tests/notebook.py
+++ b/tests/notebook.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+from memestra import nbmemestra
+
+class NotebookTest(TestCase):
+
+    def test_nb_demo(self):
+        output = nbmemestra.nbmemestra("tests/misc/memestra_nb_demo.ipynb", ('decoratortest', 'deprecated'), "tests/misc/memestra_nb_demo.ipynb")
+        expected_output = [('some_module.foo', 'Cell[0]', 2, 0),
+                           ('some_module.foo', 'Cell[0]', 3, 0),
+                           ('some_module.foo', 'Cell[2]', 1, 0)]
+        self.assertEqual(output, expected_output)

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -14,7 +14,9 @@ class NotebookTest(TestCase):
     def test_nb_demo(self):
         output = nbmemestra.nbmemestra(os.path.join(this_dir, 'misc',
                                        'memestra_nb_demo.ipynb'),
-                                       ('decoratortest', 'deprecated'))
+                                       ('decoratortest', 'deprecated'),
+                                       os.path.join(this_dir, 'misc',
+                                       'memestra_nb_demo.ipynb'))
         expected_output = [('some_module.foo', 'Cell[0]', 2, 0),
                            ('some_module.foo', 'Cell[0]', 3, 0),
                            ('some_module.foo', 'Cell[2]', 2, 4)]


### PR DESCRIPTION
Hey @serge-sans-paille, so this is the re-implementation of the new imorter logic.
Now you can do `memestra subdir/some_code.py` and get a result.