### PR TITLE
Implement recursive handling of import

### DIFF
--- a/memestra/caching.py
+++ b/memestra/caching.py
@@ -194,7 +194,12 @@ class RecursiveCacheKeyFactory(CacheKeyFactoryBase):
                 hashes = [module_hash]
 
                 for new_dep in sorted(new_deps):
-                    new_dep_key = factory(new_dep)
+                    try:
+                        new_dep_key = factory(new_dep)
+                    # FIXME: this only happens on windows, maybe we could do
+                    # better?
+                    except UnicodeDecodeError:
+                        continue
                     hashes.append(new_dep_key.module_hash)
 
                 self.module_hash = hashlib.sha256("".join(hashes).encode("ascii")).hexdigest()

--- a/memestra/memestra.py
+++ b/memestra/memestra.py
@@ -69,7 +69,10 @@ class ImportResolver(ast.NodeVisitor):
                 return []
 
         with open(module_path) as fd:
-            module = ast.parse(fd.read())
+            try:
+                module = ast.parse(fd.read())
+            except UnicodeDecodeError:
+                return []
             duc = SilentDefUseChains()
             duc.visit(module)
             anc = beniget.Ancestors()

--- a/memestra/memestra.py
+++ b/memestra/memestra.py
@@ -90,6 +90,7 @@ class ImportResolver(ast.NodeVisitor):
             deprecated = self.collect_deprecated(module, duc, anc)
             deprecated.update(deprecated_imports)
             dl = {d.name for d in deprecated}
+            dl = {d.name for d in deprecated}
             data = {'generator': 'memestra',
                     'deprecated': sorted(dl)}
             self.cache[module_key] = data
@@ -106,7 +107,7 @@ class ImportResolver(ast.NodeVisitor):
                     continue
                 deprecated_uses.append((deprecated_node, user,
                                         user_ancestors[-1] if user_ancestors
-                                        else None))
+                                        else user.node))
         return deprecated_uses
 
     def visit_Import(self, node):

--- a/memestra/memestra.py
+++ b/memestra/memestra.py
@@ -31,13 +31,30 @@ class SilentDefUseChains(beniget.DefUseChains):
         pass
 
 
-# FIXME: this is not recursive, but should be
 class ImportResolver(ast.NodeVisitor):
-    def __init__(self, decorator, file_path=None):
+
+    def __init__(self, decorator, file_path=None, recursion_depth=0, parent=None):
+        '''
+        Create an ImportResolver that finds deprecated identifiers.
+
+        A deprecated identifier is an identifier which is decorated
+        by `decorator', or which uses a deprecated identifier.
+
+        if `recursion_depth' is greater than 0, it considers identifiers
+        from imported module, with that depth in the import tree.
+
+        `parent' is used internally to handle imports.
+        '''
         self.deprecated = None
         self.decorator = tuple(decorator)
-        self.cache = Cache()
         self.file_path = file_path
+        self.recursion_depth = recursion_depth
+        if parent:
+            self.cache = parent.cache
+            self.visited = parent.visited
+        else:
+            self.cache = Cache()
+            self.visited = set()
 
     def load_deprecated_from_module(self, module_name):
         module_path = resolve_module(module_name, self.file_path)
@@ -66,12 +83,38 @@ class ImportResolver(ast.NodeVisitor):
             anc = beniget.Ancestors()
             anc.visit(module)
 
+            # Collect deprecated functions
+            if self.recursion_depth != 0 and module_path not in self.visited:
+                self.visited.add(module_path)
+                resolver = ImportResolver(self.decorator,
+                                          self.recursion_depth - 1,
+                                          parent=self)
+                resolver.visit(module)
+                deprecated_imports = [d for _, _, d in
+                                      resolver.get_deprecated_users(duc, anc)]
+            else:
+                deprecated_imports = []
             deprecated = self.collect_deprecated(module, duc, anc)
+            deprecated.update(deprecated_imports)
             dl = {d.name for d in deprecated}
             data = {'generator': 'memestra',
                     'deprecated': sorted(dl)}
             self.cache[module_key] = data
             return dl
+
+    def get_deprecated_users(self, defuse, ancestors):
+        deprecated_uses = []
+        for deprecated_node in self.deprecated:
+            for user in defuse.chains[deprecated_node].users():
+                user_ancestors = [n
+                                  for n in ancestors.parents(user.node)
+                                  if isinstance(n, _defs)]
+                if any(f in self.deprecated for f in user_ancestors):
+                    continue
+                deprecated_uses.append((deprecated_node, user,
+                                        user_ancestors[-1] if user_ancestors
+                                        else None))
+        return deprecated_uses
 
     def visit_Import(self, node):
         for alias in node.names:
@@ -173,7 +216,7 @@ def prettyname(node):
     return repr(node)
 
 
-def memestra(file_descriptor, decorator, file_path=None):
+def memestra(file_descriptor, decorator, file_path=None, recursive=False):
     '''
     Parse `file_descriptor` and returns a list of
     (function, filename, line, colno) tuples. Each elements
@@ -181,37 +224,34 @@ def memestra(file_descriptor, decorator, file_path=None):
     A deprecated function is a function flagged by `decorator`, where
     `decorator` is a tuple representing an import path,
     e.g. (module, attribute)
+
+    If `recursive` is set to `True`, deprecated use are
+    checked recursively throughout the *whole* module import tree. Otherwise,
+    only one level of import is checked.
     '''
 
     assert not isinstance(decorator, str) and \
            len(decorator) > 1, "decorator is at least (module, attribute)"
 
     module = ast.parse(file_descriptor.read())
-
     # Collect deprecated functions
-    resolver = ImportResolver(decorator, file_path)
+    resolver = ImportResolver(decorator, file_path,
+                              recursion_depth=-1 if recursive else 0)
     resolver.visit(module)
 
     ancestors = resolver.ancestors
     duc = resolver.def_use_chains
 
     # Find their users
-    deprecate_uses = []
-    for deprecated_node in resolver.deprecated:
-        for user in duc.chains[deprecated_node].users():
-            user_ancestors = (n
-                              for n in ancestors.parents(user.node)
-                              if isinstance(n, _defs))
-            if any(f in resolver.deprecated for f in user_ancestors):
-                continue
+    formated_deprecated = []
+    for deprecated_node, user, _ in resolver.get_deprecated_users(duc, ancestors):
+        formated_deprecated.append((prettyname(deprecated_node),
+                               getattr(file_descriptor, 'name', '<>'),
+                               user.node.lineno,
+                               user.node.col_offset))
 
-            deprecate_uses.append((prettyname(deprecated_node),
-                                   getattr(file_descriptor, 'name', '<>'),
-                                   user.node.lineno,
-                                   user.node.col_offset))
-
-    deprecate_uses.sort()
-    return deprecate_uses
+    formated_deprecated.sort()
+    return formated_deprecated
 
 
 def run():
@@ -222,6 +262,9 @@ def run():
     parser = argparse.ArgumentParser(description='Check decorator usage.')
     parser.add_argument('--decorator', dest='decorator',
                         default='decorator.deprecated',
+                        help='Path to the decorator to check')
+    parser.add_argument('--recursive', dest='recursive',
+                        default='store_false',
                         help='Path to the decorator to check')
     parser.add_argument('input', type=argparse.FileType('r'),
                         help='file to scan')
@@ -236,7 +279,8 @@ def run():
 
     deprecate_uses = dispatcher[extension](args.input,
                                            args.decorator.split('.'),
-                                           args.input.name)
+                                           args.input.name,
+                                           args.recursive)
 
     for fname, fd, lineno, colno in deprecate_uses:
         print("{} used at {}:{}:{}".format(fname, fd, lineno, colno + 1))

--- a/memestra/utils.py
+++ b/memestra/utils.py
@@ -1,0 +1,16 @@
+import os
+import sys
+from itertools import chain
+
+# FIXME: this only handles module name not subpackages
+def resolve_module(module_name, importer_path=()):
+    module_path = module_name + ".py"
+    bases = sys.path
+    if importer_path:
+        bases = chain(os.path.abspath(
+            os.path.dirname(importer_path)), sys.path)
+    for base in bases:
+        fullpath = os.path.join(base, module_path)
+        if os.path.exists(fullpath):
+            return fullpath
+    return

--- a/tests/misc/some_rec_module.py
+++ b/tests/misc/some_rec_module.py
@@ -1,0 +1,7 @@
+import some_module
+
+def foo():
+    return some_module.foo()
+
+def bar():
+    return some_module.bar()

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -21,7 +21,7 @@ class TestCaching(TestCase):
         try:
             os.environ['XDG_CONFIG_HOME'] = tmpdir
             cache = memestra.caching.Cache()
-            key = memestra.caching.CacheKey(__file__)
+            key = memestra.caching.CacheKeyFactory()(__file__)
             self.assertNotIn(key, cache)
             cache[key] = {}
             self.assertIn(key, cache)
@@ -33,7 +33,7 @@ class TestCaching(TestCase):
         try:
             os.environ['XDG_CONFIG_HOME'] = tmpdir
             cache = memestra.caching.Cache()
-            key = memestra.caching.CacheKey(__file__)
+            key = memestra.caching.CacheKeyFactory()(__file__)
             self.assertNotIn(key, cache)
             cache[key] = {}
             data = cache[key]
@@ -49,7 +49,7 @@ class TestCaching(TestCase):
         try:
             os.environ['XDG_CONFIG_HOME'] = tmpdir
             cache = memestra.caching.Cache()
-            key = memestra.caching.CacheKey(__file__)
+            key = memestra.caching.CacheKeyFactory()(__file__)
             with self.assertRaises(ValueError):
                 cache[key] = {'version': -1,
                               'deprecated': [],

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -69,3 +69,52 @@ class TestImports(TestCase):
         self.checkDeprecatedUses(
             code,
             [('Module.foo', '<>', 5, 4), ('Module.foo', '<>', 8, 0)])
+
+class TestRecImports(TestCase):
+
+    def checkDeprecatedUses(self, code, expected_output):
+        sio = StringIO(dedent(code))
+        output = memestra.memestra(sio, ('decoratortest', 'deprecated'),
+                                   recursive=True)
+        self.assertEqual(output, expected_output)
+
+    def test_import(self):
+        code = '''
+            import some_rec_module
+
+            def foobar():
+                some_rec_module.foo()
+                some_rec_module.bar()
+
+            some_rec_module.foo()'''
+
+        self.checkDeprecatedUses(
+            code,
+            [('some_rec_module.foo', '<>', 5, 4),
+             ('some_rec_module.foo', '<>', 8, 0)])
+
+    def test_import_from0(self):
+        code = '''
+            from some_rec_module import foo
+
+            def foobar():
+                foo()
+
+            foo()'''
+
+        self.checkDeprecatedUses(
+            code,
+            [('foo', '<>', 5, 4), ('foo', '<>', 7, 0)])
+
+    def test_import_from1(self):
+        code = '''
+            from some_rec_module import bar
+
+            def foobar():
+                bar()
+
+            bar()'''
+
+        self.checkDeprecatedUses(
+            code,
+            [])


### PR DESCRIPTION
The recursive strategy basically states that if a symbol uses a symbol that uses
a symbol that... uses a deprecated symbol, even within a deep module hierarchy,
it is deprecated.

- it's optional
- it's still incompatible with the caching system (no dep handling)