### PR TITLE
Support detection of decorator with parameters

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -212,3 +212,21 @@ class TestClassBasic(TestCase):
         self.checkDeprecatedUses(
             code,
             [('foo', '<>', 11, 0),])
+
+    def test_decoarator_with_param(self):
+        code = '''
+            from decoratortest import deprecated as dp
+
+            @dp()
+            class foo(object): pass
+
+            @dp("ignored")
+            def bar(x):
+                foo()
+
+            bar(foo)'''
+
+        self.checkDeprecatedUses(
+            code,
+            [('bar', '<>', 11, 0),
+             ('foo', '<>', 11, 4)])


### PR DESCRIPTION
The actual arguments are ignored, but the decorated function is correctly
flagged as deprecated.