### PR TITLE
Also store reason of deprecation, if any, in the cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ install:
 # command to run tests
 script:
   - pytest -v
+  - pytest -v  # run test twic because the first run populates the cache, so they are not exactly equivalent

--- a/tests/misc/some_module.py
+++ b/tests/misc/some_module.py
@@ -4,3 +4,6 @@ from decoratortest import deprecated
 def foo(): pass
 
 def bar(): pass
+
+@deprecated("because it's too old")
+def foobar(): pass

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -17,7 +17,8 @@ class TestImports(TestCase):
 
     def test_import_from(self):
         code = '''
-            from some_module import foo, bar
+            from some_module import foo, bar, foobar
+            foobar()
 
             def foobar():
                 foo()
@@ -27,7 +28,9 @@ class TestImports(TestCase):
 
         self.checkDeprecatedUses(
             code,
-            [('foo', '<>', 5, 4, None), ('foo', '<>', 8, 0, None)])
+            [('foo', '<>', 6, 4, None),
+             ('foo', '<>', 9, 0, None),
+             ('foobar', '<>', 3, 0, "because it's too old")])
 
     def test_import_from_as(self):
         code = '''


### PR DESCRIPTION
This is done through some mangling of the deprecated name, based on the fact
that a function name cannot contain ':'. So a deprecated name without ':' is
just a name, and a deprecated name with at least a ':' is a neame followed by a
reason.

Fix #41