### PR TITLE
Fix handling of multiple deprecations in memestra-cache

### DIFF
--- a/memestra/caching.py
+++ b/memestra/caching.py
@@ -313,8 +313,7 @@ def run():
 
     parser_set = subparsers.add_parser('set', help='Set a cache entry')
     parser_set.add_argument('--deprecated', dest='deprecated',
-                            type=str, nargs='+',
-                            default='decorator.deprecated',
+                            action='append',
                             help='function to flag as deprecated')
     parser_set.add_argument('--recursive', action='store_true',
                             help='set a dependency-aware cache key')

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -115,4 +115,5 @@ class TestCLI(TestCase):
         }
         cache = memestra.caching.Cache()
         key = memestra.caching.CacheKeyFactory()(tmppy.name)
+        os.remove(tmppy.name)
         self.assertEqual(cache[key], expected)


### PR DESCRIPTION
When specifying multiple items to deprecate, memestra-cache will only use the last one.

For example:
```
memestra-cache set --deprecated Test --deprecated Test2 --recursive testimport.py
```
Will only add Test2 to the cache. This PR addresses this issue by fixing the way the --deprecation argument is handled.