### PR TITLE
Add support for specifying where the cache is stored

### DIFF
--- a/memestra/caching.py
+++ b/memestra/caching.py
@@ -211,7 +211,7 @@ class RecursiveCacheKeyFactory(CacheKeyFactoryBase):
 class Cache(object):
 
     def __init__(self, cache_dir=None):
-        if cache_dir:
+        if cache_dir is not None:
             self.cachedir = cache_dir
         else:
             xdg_config_home = os.environ.get('XDG_CONFIG_HOME', None)

--- a/memestra/caching.py
+++ b/memestra/caching.py
@@ -210,16 +210,20 @@ class RecursiveCacheKeyFactory(CacheKeyFactoryBase):
 
 class Cache(object):
 
-    def __init__(self):
-        xdg_config_home = os.environ.get('XDG_CONFIG_HOME', None)
-        if xdg_config_home is None:
-            user_config_dir = '~'
-            memestra_dir = '.memestra'
+    def __init__(self, cache_dir=None):
+        if cache_dir:
+            self.cachedir = cache_dir
         else:
-            user_config_dir = xdg_config_home
-            memestra_dir = 'memestra'
-        self.cachedir = os.path.expanduser(os.path.join(user_config_dir,
-                                                        memestra_dir))
+            xdg_config_home = os.environ.get('XDG_CONFIG_HOME', None)
+            if xdg_config_home is None:
+                user_config_dir = '~'
+                memestra_dir = '.memestra'
+            else:
+                user_config_dir = xdg_config_home
+                memestra_dir = 'memestra'
+            self.cachedir = os.path.expanduser(os.path.join(user_config_dir,
+                                                            memestra_dir))
+
         os.makedirs(self.cachedir, exist_ok=True)
 
     def _get_path(self, key):
@@ -263,7 +267,7 @@ class Cache(object):
 def run_set(args):
     data = {'generator': 'manual',
             'deprecated': args.deprecated}
-    cache = Cache()
+    cache = Cache(cache_dir=args.cache_dir)
     if args.recursive:
         key_factory = RecursiveCacheKeyFactory()
     else:
@@ -273,13 +277,13 @@ def run_set(args):
 
 
 def run_list(args):
-    cache = Cache()
+    cache = Cache(cache_dir=args.cache_dir)
     for k, v in cache.items():
         print('{}: {} ({})'.format(k, v['name'], len(v['deprecated'])))
 
 
 def run_clear(args):
-    cache = Cache()
+    cache = Cache(cache_dir=args.cache_dir)
     nb_cleared = cache.clear()
     print('Cache cleared, {} element{} removed.'.format(nb_cleared, 's' *
                                                         (nb_cleared > 1)))
@@ -288,7 +292,7 @@ def run_clear(args):
 def run_docparse(args):
     deprecated = docparse(args.input, args.pattern)
 
-    cache = Cache()
+    cache = Cache(cache_dir=args.cache_dir)
     if args.recursive:
         key_factory = RecursiveCacheKeyFactory()
     else:
@@ -310,6 +314,11 @@ def run():
     parser = argparse.ArgumentParser(
         description='Interact with memestra cache')
     subparsers = parser.add_subparsers()
+
+    parser.add_argument('--cache-dir', dest='cache_dir',
+                        default=None,
+                        action='store',
+                        help='The directory where the cache is located')
 
     parser_set = subparsers.add_parser('set', help='Set a cache entry')
     parser_set.add_argument('--deprecated', dest='deprecated',

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -22,9 +22,10 @@ class TestCaching(TestCase):
 
     def test_cache_dir(self):
         tmpdir = tempfile.mkdtemp()
+        cachedir = os.path.join(tmpdir, "memestra-test")
         try:
-            cache = memestra.caching.Cache(cache_dir=tmpdir)
-            self.assertTrue(os.path.isdir(os.path.join(tmpdir)))
+            cache = memestra.caching.Cache(cache_dir=cachedir)
+            self.assertTrue(os.path.isdir(cachedir))
         finally:
             shutil.rmtree(tmpdir)
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -20,6 +20,14 @@ class TestCaching(TestCase):
         finally:
             shutil.rmtree(tmpdir)
 
+    def test_cache_dir(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            cache = memestra.caching.Cache(cache_dir=tmpdir)
+            self.assertTrue(os.path.isdir(os.path.join(tmpdir)))
+        finally:
+            shutil.rmtree(tmpdir)
+
     def test_contains(self):
         tmpdir = tempfile.mkdtemp()
         try:

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -153,5 +153,6 @@ class TestCLI(TestCase):
             cachefile = os.path.join(tmpdir, key.module_hash)
             self.assertTrue(os.path.isfile(cachefile))
         finally:
-            shutil.rmtree(tmpdir)
             os.remove(tmppy.name)
+            shutil.rmtree(tmpdir)
+

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -154,3 +154,4 @@ class TestCLI(TestCase):
             self.assertTrue(os.path.isfile(cachefile))
         finally:
             shutil.rmtree(tmpdir)
+            os.remove(tmppy.name)

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -128,28 +128,28 @@ class TestCLI(TestCase):
         self.assertEqual(cache[key], expected)
 
     def test_cache_dir(self):
-        fid, tmppy = tempfile.mkstemp(suffix='.py')
-        code = '''
-            def foo()
-                pass
+        with tempfile.NamedTemporaryFile(suffix='.py', delete=False) as tmppy:
+            code = '''
+                def foo()
+                    pass
 
-            foo()'''
+                foo()'''
 
-        ref = ''
-        os.write(fid, dedent(code).encode())
-        os.close(fid)
+            tmppy.write(dedent(code).encode())
+
         try:
             tmpdir = tempfile.mkdtemp()
+            ref = ''
             set_args = ['memestra-cache',
                         '--cache-dir=' + tmpdir,
                         'set',
                         '--deprecated=foo',
-                        tmppy]
+                        tmppy.name]
             with mock.patch.object(sys, 'argv', set_args):
                 from memestra.caching import run
                 run()
 
-            key = memestra.caching.CacheKeyFactory()(tmppy)
+            key = memestra.caching.CacheKeyFactory()(tmppy.name)
             cachefile = os.path.join(tmpdir, key.module_hash)
             self.assertTrue(os.path.isfile(cachefile))
         finally:


### PR DESCRIPTION
This change adds support for changing the directory where the cache is stored. The CLI tools have been updated to take a --cache-dir parameter. The API has been updated to take a cache_dir argument as well.

I added one test case for this, but it seems like I should add more. Any suggestions?