### PR TITLE
Improve module resolution

### DIFF
--- a/memestra/caching.py
+++ b/memestra/caching.py
@@ -20,7 +20,7 @@ class DependenciesResolver(ast.NodeVisitor):
         self.result = set()
 
     def add_module(self, module_name):
-        module_path = resolve_module(module_name)
+        module_path, _ = resolve_module(module_name)
         if module_path is not None:
             self.result.add(module_path)
 

--- a/memestra/utils.py
+++ b/memestra/utils.py
@@ -1,16 +1,38 @@
 import os
 import sys
-from itertools import chain
+from importlib import util
+from importlib.abc import SourceLoader
 
-# FIXME: this only handles module name not subpackages
-def resolve_module(module_name, importer_path=()):
-    module_path = module_name + ".py"
-    bases = sys.path
-    if importer_path:
-        bases = chain([os.path.abspath(
-            os.path.dirname(importer_path))], sys.path)
-    for base in bases:
-        fullpath = os.path.join(base, module_path)
-        if os.path.exists(fullpath):
-            return fullpath
-    return
+def resolve_module(module_name):
+    if module_name is None or module_name == "__main__":
+        return None, None
+
+    parent, _, module_name = module_name.rpartition(".")
+    search_path = None
+
+    if parent != "":
+        parent_spec, search_path = resolve_module(parent)
+        if parent_spec is None:
+            return None, None
+
+    try:
+        spec = None
+        for finder in sys.meta_path:
+            try:
+                spec = finder.find_spec(module_name, search_path)
+            except AttributeError:
+                pass
+
+            if spec is not None:
+                break
+
+        origin = spec.origin if spec else None
+        if spec is None or spec.origin is None:
+            return None, None
+        if not isinstance(spec.loader, SourceLoader):
+            return None, None
+        else:
+            return spec.origin, spec.submodule_search_locations
+
+    except ModuleNotFoundError:
+        return None, []

--- a/memestra/utils.py
+++ b/memestra/utils.py
@@ -3,12 +3,12 @@ import sys
 from importlib import util
 from importlib.abc import SourceLoader
 
-def resolve_module(module_name):
+def resolve_module(module_name, additional_search_paths=[]):
     if module_name is None or module_name == "__main__":
         return None, None
 
     parent, _, module_name = module_name.rpartition(".")
-    search_path = None
+    search_path = sys.path + additional_search_paths
 
     if parent != "":
         parent_spec, search_path = resolve_module(parent)


### PR DESCRIPTION
Memestra does not handle importing package, or relative imports. This PR improves the way modules are resolved by using parts of Python's module import system. Packages( with an __init__.py), and relative imports seem to be working.

There are still some issues to work out, and there are no tests, so I'm creating a draft PR to get some early feedback.