### PR TITLE
Do not ignore identifiers forwarded from one module to another

### DIFF
--- a/tests/misc/module_defining_symbol.py
+++ b/tests/misc/module_defining_symbol.py
@@ -1,0 +1,5 @@
+import decoratortest
+
+@decoratortest.deprecated
+class Test:
+  pass

--- a/tests/misc/module_forwarding_symbol.py
+++ b/tests/misc/module_forwarding_symbol.py
@@ -1,0 +1,2 @@
+from module_defining_symbol import Test
+from module_defining_symbol import Test as Testosterone

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -108,7 +108,9 @@ class TestRecImports(TestCase):
 
         self.checkDeprecatedUses(
             code,
-            [('foo', '<>', 5, 4, None), ('foo', '<>', 7, 0, None)])
+            [('foo', '<>', 2, 0, None),
+             ('foo', '<>', 5, 4, None),
+             ('foo', '<>', 7, 0, None)])
 
     def test_import_from1(self):
         code = '''
@@ -122,3 +124,31 @@ class TestRecImports(TestCase):
         self.checkDeprecatedUses(
             code,
             [])
+
+    def test_forwarding_symbol0(self):
+        code = '''
+            from module_forwarding_symbol import Test
+            t = Test()'''
+
+        self.checkDeprecatedUses(
+            code,
+            [('Test', '<>', 2, 0, None), ('Test', '<>', 3, 4, None)])
+
+    def test_forwarding_symbol1(self):
+        code = '''
+            import module_forwarding_symbol
+            t = module_forwarding_symbol.Test()'''
+
+        self.checkDeprecatedUses(
+            code,
+            [('module_forwarding_symbol.Test', '<>', 3, 4, None)])
+
+    def test_forwarding_symbol2(self):
+        code = '''
+            from module_forwarding_symbol import Testosterone
+            t = Testosterone()'''
+
+        self.checkDeprecatedUses(
+            code,
+            [('Testosterone', '<>', 2, 0, None),
+             ('Testosterone', '<>', 3, 4, None)])


### PR DESCRIPTION
Stated otherwise, a module or symbol imported at global scope also needs to be
listed as the deprecated use of that module, even if it's not called by a
function in that module.

This is only active under the recursive option.