### PR TITLE
Fix interplay between star import and sub package

### DIFF
--- a/tests/misc/ipy/__init__.py
+++ b/tests/misc/ipy/__init__.py
@@ -1,0 +1,1 @@
+from .a import *

--- a/tests/misc/ipy/a/__init__.py
+++ b/tests/misc/ipy/a/__init__.py
@@ -1,0 +1,1 @@
+from .b import foo

--- a/tests/misc/ipy/a/b.py
+++ b/tests/misc/ipy/a/b.py
@@ -1,0 +1,4 @@
+from decoratortest import deprecated
+
+@deprecated("why")
+def foo():pass

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -215,3 +215,13 @@ class TestImportPkg(TestCase):
         self.checkDeprecatedUses(
             code,
             [('other', '<>', 2, 0, None), ('other', '<>', 5, 4, None)])
+
+    def test_import_pkg_level_star(self):
+        code = '''
+            from ipy import foo
+
+            b = foo()'''
+
+        self.checkDeprecatedUses(
+            code,
+            [('foo', '<>', 2, 0, 'why'), ('foo', '<>', 4, 4, 'why')])


### PR DESCRIPTION
The key was to use a new importer instance with pkg_name correctly set when
doing star import.

Fix #49