### PR TITLE
Add a MEMESTRA_PREFIX environment variable to allow configuration of the shared cache directory

### DIFF
--- a/memestra/caching.py
+++ b/memestra/caching.py
@@ -222,7 +222,11 @@ class RecursiveCacheKeyFactory(CacheKeyFactoryBase):
 class SharedCache(object):
 
     def __init__(self):
-        shared_dir = os.path.join(sys.prefix, 'share', 'memestra')
+        shared_dir = os.path.join(
+            os.environ.get("MEMESTRA_PREFIX", sys.prefix),
+            'share',
+            'memestra',
+        )
         os.makedirs(shared_dir, exist_ok=True)
         self.cache_entries = {}
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -245,18 +245,22 @@ class TestImportPkg(TestCase):
             code,
             [('foo', '<>', 4, 4, 'why')])
 
+    @mock.patch.dict(
+        # We have a fake description for gast in tests/share/memestra
+        # Setup the shared cache to use it.
+        os.environ, {"MEMESTRA_PREFIX": os.path.dirname(__file__)}
+    )
     def test_shared_cache(self):
-        # We have a fake description for gast in tests/share/memestra
-        # Setup the shared cache to use it.
-        with mock.patch('sys.prefix', os.path.dirname(__file__)):
-            self.checkDeprecatedUses(
-                'from gast import parse',
-                [('parse', '<>', 1, 0, None)])
+        self.checkDeprecatedUses(
+            'from gast import parse',
+            [('parse', '<>', 1, 0, None)])
 
-    def test_shared_cache_sub(self):
+    @mock.patch.dict(
         # We have a fake description for gast in tests/share/memestra
         # Setup the shared cache to use it.
-        with mock.patch('sys.prefix', os.path.dirname(__file__)):
-            self.checkDeprecatedUses(
-                'from gast.astn import AstToGAst',
-                [('AstToGAst', '<>', 1, 0, 'because')])
+        os.environ, {"MEMESTRA_PREFIX": os.path.dirname(__file__)}
+    )
+    def test_shared_cache_sub(self):
+        self.checkDeprecatedUses(
+            'from gast.astn import AstToGAst',
+            [('AstToGAst', '<>', 1, 0, 'because')])


### PR DESCRIPTION
This PR adds a `MEMESTRA_PREFIX` environment variable
to allow testing of memestra when `sys.prefix` isn't writable.

The change is backwards compatible with existing code, since if
`MEMESTRA_PREFIX` isn't defined in the environment then the code
falls back to `sys.prefix`.
