### PR TITLE
cache per interpreter

### DIFF
--- a/memestra/caching.py
+++ b/memestra/caching.py
@@ -265,8 +265,15 @@ class Cache(object):
             else:
                 user_config_dir = xdg_config_home
                 memestra_dir = 'memestra'
-            self.cachedir = os.path.expanduser(os.path.join(user_config_dir,
-                                                            memestra_dir))
+
+            # use a path that is dependent on the interpeter version to avoid
+            # polluting the cache from other interpreters
+            interpreter_path = os.path.join(
+                *os.path.abspath(sys.executable).split(os.sep)[1:]
+            )
+            self.cachedir = os.path.expanduser(
+                os.path.join(user_config_dir, memestra_dir, interpreter_path)
+            )
         os.makedirs(self.cachedir, exist_ok=True)
 
     def _get_path(self, key):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -70,6 +70,16 @@ class TestCaching(TestCase):
         finally:
             shutil.rmtree(tmpdir)
 
+    def test_cache_is_tied_to_interpreter(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ['XDG_CONFIG_HOME'] = tmpdir
+            cache = memestra.caching.Cache()
+            self.assertIn(
+                os.path.join(*sys.executable.split(os.sep)[1:]),
+                cache.cachedir,
+            )
+
+
 class TestCLI(TestCase):
 
     def test_docparse(self):


### PR DESCRIPTION
This PR is one implementation of a solution to address #61.

The problem is that when traversing the standard library, memestra can potentially (and does)
cache a standard library module's code from a potentially different version of Python than the
one that created the cache entry. This hides bugs in the cache implementation for different versions
of Python, because the cache will be hit regardless of the version.

The implementation here creates a directory below the top level cache directory that
is equivalent to `sys.executable` with any leading path separators or drives (in the case of Windows)
removed.

The effect is that there's a distinct cache per interpreter.

One caveat is that on some systems, an upgrade of the system python, for example `/usr/bin/python3`,
can result in a similar bug being hidden on such systems. I'm not sure whether
that case (development environments that use the system Python) is common
enough to warrant addressing in this PR.

Closes #61.
