### PR TITLE
fix return

### DIFF
--- a/memestra/memestra.py
+++ b/memestra/memestra.py
@@ -133,7 +133,7 @@ class ImportResolver(ast.NodeVisitor):
             try:
                 module, syntax_errors = frilouz.parse(ast.parse, fd.read())
             except UnicodeDecodeError:
-                return []
+                return {}
             duc = SilentDefUseChains()
             duc.visit(module)
             anc = beniget.Ancestors()


### PR DESCRIPTION
```sh
LSP-pylsp:   File "C:\Users\zangwill\AppData\Local\Programs\Python\Python310\lib\site-packages\memestra\memestra.py", line 255, in visit_ImportFrom
LSP-pylsp:     for deprec, reason in deprecated.items():
LSP-pylsp: AttributeError: 'list' object has no attribute 'items'
````